### PR TITLE
Add preload value to rel attribute in separated panel prefs edit frame

### DIFF
--- a/src/framework/preferences/html/SeparatedPanelPrefsEditorFrame.html
+++ b/src/framework/preferences/html/SeparatedPanelPrefsEditorFrame.html
@@ -4,13 +4,13 @@
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <meta content="width=device-width, initial-scale=1.0" name="viewport">
 
-        <link rel="stylesheet" type="text/css" href="../../../lib/normalize/css/normalize.css" />
-        <link rel="stylesheet" type="text/css" href="../../../framework/core/css/fluid.css" />
+        <link rel="preload" href="../../../lib/normalize/css/normalize.css" as="style" onload="this.rel='stylesheet'" />
+        <link rel="preload" href="../../../framework/core/css/fluid.css" as="style" onload="this.rel='stylesheet'" />
 
         <!-- Component styles -->
-        <link rel="stylesheet" type="text/css" href="../css/Enactors.css" />
-        <link rel="stylesheet" type="text/css" href="../css/PrefsEditor.css" />
-        <link rel="stylesheet" type="text/css" href="../css/SeparatedPanelPrefsEditorFrame.css" />
+        <link rel="preload" href="../css/Enactors.css" as="style" onload="this.rel='stylesheet'"/>
+        <link rel="preload" href="../css/PrefsEditor.css" as="style" onload="this.rel='stylesheet'" />
+        <link rel="preload" href="../css/SeparatedPanelPrefsEditorFrame.css" as="style" onload="this.rel='stylesheet'" />
 
         <title>Preferences Editor</title>
      </head>


### PR DESCRIPTION
## Description

Use <link rel=preload> to prioritize [fetching resources](https://web.dev/uses-rel-preload/?utm_source=lighthouse&utm_medium=devtools) that are currently requested later in page load 

<!-- Description of the pull request -->

## Steps to test

1. right clink on We Count webpage and go to inspect
2. go to audit tab and run lighthouse 

**Expected behavior:** <!-- What should happen -->

Preload key requests should no longer be an opportunity to improve performance because it has already been applied.

## Additional information

<!-- Please provide any additional information that can help us review your contribution. -->

There may be other link tags that we can apply preloads to that can improve performance

## Related issues

<!-- If this pull request resolves an issue, please indicate the issue number here, e.g. 'Resolves #42' -->