### PR TITLE
fix: added swap value to font display for prefsframework-icons

### DIFF
--- a/src/framework/preferences/css/stylus/PrefsEditor.styl
+++ b/src/framework/preferences/css/stylus/PrefsEditor.styl
@@ -7,6 +7,7 @@
 @font-face {
     font-family: 'PrefsFramework-Icons';
     src: url('../fonts/PrefsFramework-Icons.woff');
+    font-display: swap;
 }
 
 .fl-prefsEditor {


### PR DESCRIPTION
## Description

Leverage the [font-display CSS feature](https://web.dev/font-display/?utm_source=lighthouse&utm_medium=devtools#how-to-avoid-showing-invisible-text) to ensure text is user-visible while webfonts are loading.

<!-- Description of the pull request -->

## Steps to test

1. right click on We Count webpage and go to inspect
2. go to audit tab and run lighthouse 

**Expected behavior:** <!-- What should happen -->

_Ensure text remains visible during webfont load_ should no longer come up under Diagnostics because it has already been applied.

## Additional information

<!-- Please provide any additional information that can help us review your contribution. -->

There may be other `@font-face` that we can apply `font-display: swap;` to that can improve performance

## Related issues

<!-- If this pull request resolves an issue, please indicate the issue number here, e.g. 'Resolves #42' -->