### PR TITLE
fix: added stylesheet link along with preload to account for mozilla b…

### DIFF
--- a/src/framework/preferences/html/SeparatedPanelPrefsEditorFrame.html
+++ b/src/framework/preferences/html/SeparatedPanelPrefsEditorFrame.html
@@ -4,13 +4,23 @@
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <meta content="width=device-width, initial-scale=1.0" name="viewport">
 
-        <link rel="preload" href="../../../lib/normalize/css/normalize.css" as="style" onload="this.rel='stylesheet'" />
-        <link rel="preload" href="../../../framework/core/css/fluid.css" as="style" onload="this.rel='stylesheet'" />
+        <!-- PRELOADS -->
+        <link rel="preload" href="../../../lib/normalize/css/normalize.css" as="style" />
+        <link rel="preload" href="../../../framework/core/css/fluid.css" as="style" />
 
         <!-- Component styles -->
-        <link rel="preload" href="../css/Enactors.css" as="style" onload="this.rel='stylesheet'"/>
-        <link rel="preload" href="../css/PrefsEditor.css" as="style" onload="this.rel='stylesheet'" />
-        <link rel="preload" href="../css/SeparatedPanelPrefsEditorFrame.css" as="style" onload="this.rel='stylesheet'" />
+        <link rel="preload" href="../css/Enactors.css" as="style" />
+        <link rel="preload" href="../css/PrefsEditor.css" as="style" />
+        <link rel="preload" href="../css/SeparatedPanelPrefsEditorFrame.css" as="style" />
+
+        <!-- STYLESHEETS -->
+        <link rel="stylesheet" type="text/css" href="../../../lib/normalize/css/normalize.css" />
+        <link rel="stylesheet" type="text/css" href="../../../framework/core/css/fluid.css" />
+
+        <!-- Component styles -->
+        <link rel="stylesheet" type="text/css" href="../css/Enactors.css" />
+        <link rel="stylesheet" type="text/css" href="../css/PrefsEditor.css" />
+        <link rel="stylesheet" type="text/css" href="../css/SeparatedPanelPrefsEditorFrame.css" />
 
         <title>Preferences Editor</title>
      </head>


### PR DESCRIPTION
## Description

Add link element with `rel` value set to `stylesheet` along with preload for mozilla browsers.

<!-- Description of the pull request -->

## Steps to test

1. Test using mozilla browser
2. Click on UIO tab in top right corner and make sure styles are being applied and UIO is functioning properly
3. Right click on We Count webpage and go to inspect
4. Make sure no warnings having to do with preloads are coming up 

**Expected behavior:** <!-- What should happen -->
* Styling should be applied to UIO
* No warnings in console having to do with preloads

## Additional information

<!-- Please provide any additional information that can help us review your contribution. -->

## Related issues

<!-- If this pull request resolves an issue, please indicate the issue number here, e.g. 'Resolves #42' -->